### PR TITLE
Fix stack smashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,6 @@ $(OBJDIR)/%.o: %.c
 clean:
 	rm -rf obj; \
 	rm -f test_mindi; \
-	rm -rf bin
-
+	rm -rf bin; \
+	rm -f src/main.o; \
+	rm -f mididump

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Extremely minimal MIDI library, for old or otherwise resource-limited systems.
 
 Currently a work in progress and very volatile.
 
+## Dependencies
+
+- Check framework:
+`sudo apt install check`
+
 ## References
 
 - https://web.archive.org/web/20140216225718/http://www.sonicspot.com/guide/midifiles.html

--- a/src/main.c
+++ b/src/main.c
@@ -10,11 +10,11 @@
 #include <stdlib.h>
 
 int main( int argc, char** argv ) {
-   int midi_handle = 0,
+   int midi_handle = -1,
       track_seek = -1,
       track_iter = 0;
    struct stat st;
-   uint8_t* midi_map = NULL,
+   uint8_t* midi_map = MAP_FAILED,
       midi_params[10] = { 0 },
       evt_type = 0;
    int32_t track_offset = 0,
@@ -78,7 +78,7 @@ cleanup:
       close( midi_handle );
    }
 
-   if( NULL != midi_map ) {
+   if( MAP_FAILED != midi_map ) {
       munmap( midi_map, midi_bytes_sz );
    }
 

--- a/src/mindievt.c
+++ b/src/mindievt.c
@@ -140,6 +140,11 @@ uint8_t mindi_event_type(
       goto cleanup;
    }
 
+   if( params_sz > params_out_sz ) {
+      /* Give up due to out of bounds. */
+      goto cleanup;
+   }
+
    /* Copy params to output buffer. */
    for( i = 0 ; params_sz > i ; i++ ) {
       params_out[i] = midi_bytes[offset + time_sz + evt_byte_ct + i];


### PR DESCRIPTION
Trivial PR that fixes stack smashing (-fstack-protector) when MIDI input file results in "param_sz > param_out_sz"

Also it documents required Check framework "check" package dependency.

Some minor default fd/map ptr default values.
